### PR TITLE
Small change to tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Ways to create a list
 ```
 
 #### Tuples
-Tuples package two or more expressions into a single expression. 
+Tuples package two or more (up to nine) expressions into a single expression. 
 The type of a tuple records the number of components and each of their types.
 ```elm
 > (1, "2", True)


### PR DESCRIPTION
Hi, 

I think that there's a limit on the number of things you can put into a tuple - I got the following behavior when in elm-repl (version 0.16.0)

```
> (,,,,,,,,) 1 2 3 4 5 6 7 8 9
(1,2,3,4,5,6,7,8,9)
    : ( number
      , number'
      , number''
      , number'''
      , number''''
      , number'''''
      , number''''''
      , number'''''''
      , number''''''''
      )
> (,,,,,,,,,) 1 2 3 4 5 6 7 8 9 10
elm-make: Could not find `_Tuple10` when solving type constraints.
elm-make: thread blocked indefinitely in an MVar operation
```
