### PR TITLE
Fix type hint for `not`

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ In a nutshell Elm operators are _functions_.
 |--------|-----------|----------|
 |`&&`|logical and|`Bool -> Bool -> Bool`
 |`||`|logical or|`Bool -> Bool -> Bool`
-|`not`|logical not|`Bool`
+|`not`|logical not|`Bool -> Bool`
 
 #### Function Composition
 |Operator|Description|Type hint|


### PR DESCRIPTION
http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Basics#not
