### PR TITLE
fixed directory names in Sub... example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ source-directories": [
 
 ├── SubOne
 │   └── SubOne.elm        # Compiled and exposed
-├── SubOne
+├── SubTwo
 │   └── SubTwo.elm        # Compiled, but unexposed
-├── SubOne
+├── SubThree
 │   └── SubThree.elm      # Compiler won't see the source, unexposed to the users 
 ├── README.md
 ├── elm-package.json


### PR DESCRIPTION
Just a small typo fix - the directory names for SubTwo and SubThree are wrong IMHO.
